### PR TITLE
Add unitests for kill() around SIGTERM handling

### DIFF
--- a/pshell/tests/data/sleep20_sigterm_delay5.py
+++ b/pshell/tests/data/sleep20_sigterm_delay5.py
@@ -10,7 +10,7 @@ import time
 
 def _handler(signum, _frame):
     """Print the incoming signal, sleep for 5s then gracefully exit."""
-    print(f'Receive signal {signum}')
+    print('Receive signal {signum}'.format(signum=signum))
     time.sleep(5)
     sys.exit(0)
 

--- a/pshell/tests/data/sleep20_sigterm_delay5.py
+++ b/pshell/tests/data/sleep20_sigterm_delay5.py
@@ -22,7 +22,7 @@ def main():
 
     for i in range(1, 20 + 1):
         time.sleep(1)
-        print(f'{pid}: count {i}')
+        print('{pid}: count {i}'.format(pid=pid, i=i))
     sys.exit(0)
 
 

--- a/pshell/tests/data/sleep20_sigterm_delay5.py
+++ b/pshell/tests/data/sleep20_sigterm_delay5.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 """Simple script that executes for 20s, and gracefully shuts down in 5s once
 SIGTERM is received.
 """
@@ -23,7 +23,6 @@ def main():
     for i in range(1, 20 + 1):
         time.sleep(1)
         print('{pid}: count {i}'.format(pid=pid, i=i))
-    sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/pshell/tests/data/sleep20_sigterm_delay5.py
+++ b/pshell/tests/data/sleep20_sigterm_delay5.py
@@ -1,0 +1,30 @@
+#! /usr/bin/env python
+"""Simple script that executes for 20s, and gracefully shuts down in 5s once
+SIGTERM is received.
+"""
+import os
+import signal
+import sys
+import time
+
+
+def _handler(signum, _frame):
+    """Print the incoming signal, sleep for 5s then gracefully exit."""
+    print(f'Receive signal {signum}')
+    time.sleep(5)
+    sys.exit(0)
+
+
+def main():
+    """Register signal handler then sleep 1s for 20 times."""
+    pid = os.getpid()
+    signal.signal(signal.SIGTERM, _handler)
+
+    for i in range(1, 20 + 1):
+        time.sleep(1)
+        print(f'{pid}: count {i}')
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/pshell/tests/data/sleep20_sigterm_ignore.py
+++ b/pshell/tests/data/sleep20_sigterm_ignore.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+"""Simple script that executes for 20s and ignores SIGTERM.
+"""
+import os
+import signal
+import sys
+import time
+
+
+def _handler(signum, _frame):
+    """Print the incoming signal, then do nothing."""
+    print(f'Receive signal {signum}')
+
+
+def main():
+    """Register signal handler then sleep 1s for 20 times."""
+    pid = os.getpid()
+    signal.signal(signal.SIGTERM, _handler)
+
+    for i in range(1, 20 + 1):
+        time.sleep(1)
+        print(f'{pid}: count {i}')
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/pshell/tests/data/sleep20_sigterm_ignore.py
+++ b/pshell/tests/data/sleep20_sigterm_ignore.py
@@ -3,7 +3,6 @@
 """
 import os
 import signal
-import sys
 import time
 
 
@@ -20,7 +19,6 @@ def main():
     for i in range(1, 20 + 1):
         time.sleep(1)
         print('{pid}: count {i}'.format(pid=pid, i=i))
-    sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/pshell/tests/data/sleep20_sigterm_ignore.py
+++ b/pshell/tests/data/sleep20_sigterm_ignore.py
@@ -9,7 +9,7 @@ import time
 
 def _handler(signum, _frame):
     """Print the incoming signal, then do nothing."""
-    print(f'Receive signal {signum}')
+    print('Receive signal {signum}'.format(signum=signum))
 
 
 def main():

--- a/pshell/tests/data/sleep20_sigterm_ignore.py
+++ b/pshell/tests/data/sleep20_sigterm_ignore.py
@@ -19,7 +19,7 @@ def main():
 
     for i in range(1, 20 + 1):
         time.sleep(1)
-        print(f'{pid}: count {i}')
+        print('{pid}: count {i}'.format(pid=pid, i=i))
     sys.exit(0)
 
 

--- a/pshell/tests/test_procs.py
+++ b/pshell/tests/test_procs.py
@@ -1,12 +1,11 @@
 import getpass
 import os
 import subprocess
+import sys
 import time
-
 
 import psutil
 import pytest
-
 
 import pshell as sh
 from . import DATADIR
@@ -110,7 +109,7 @@ def test_sigkill_sigterm_delay5():
     that shuts itself downupon receiving SIGTERM will be able to do so
     gracefully.
     """
-    cmd = ['python', os.path.join(DATADIR, 'sleep20_sigterm_delay5.py')]
+    cmd = [sys.executable, os.path.join(DATADIR, 'sleep20_sigterm_delay5.py')]
     subprocess.Popen(cmd)
     time.sleep(1)  # to allow enough time for python to start
 
@@ -138,7 +137,7 @@ def test_sigkill_sigterm_ignore():
     initial SIGTERM it receives.  The kill() will attempt to shut the process
     again later forcefully.
     """
-    cmd = ['python', os.path.join(DATADIR, 'sleep20_sigterm_ignore.py')]
+    cmd = [sys.executable, os.path.join(DATADIR, 'sleep20_sigterm_ignore.py')]
     subprocess.Popen(cmd)
     time.sleep(1)  # to allow enough time for python to start
 

--- a/pshell/tests/test_procs.py
+++ b/pshell/tests/test_procs.py
@@ -2,9 +2,13 @@ import getpass
 import os
 import subprocess
 import time
+
+
 import psutil
-import pshell as sh
 import pytest
+
+
+import pshell as sh
 from . import DATADIR
 
 
@@ -95,8 +99,57 @@ def test_kill2():
         sh.kill('foo')
 
 
-@pytest.mark.skip('TODO')
-def test_sigkill():
-    """Test terminating processes resilient to SIGTERM
+@pytest.mark.skipif(
+    os.name == 'nt',
+    reason='On Windows, os.kill() and psutil.kill() calls TerminateProcess '
+           'API which does not process signals (such as SIGTERM, SIGKILL '
+           'etc..) as ANSI/POSIX prescribed.  The TerminateProcess API '
+           'unconditionally terminates the target process.')
+def test_sigkill_sigterm_delay5():
+    """Test that kill() will send a SIGTERM to kill the target first.  Process
+    that shuts itself downupon receiving SIGTERM will be able to do so
+    gracefully.
     """
-    pass
+    cmd = ['python', os.path.join(DATADIR, 'sleep20_sigterm_delay5.py')]
+    subprocess.Popen(cmd)
+    time.sleep(1)  # to allow enough time for python to start
+
+    procs = sh.find_procs_by_cmdline(DATADIR)
+    assert len(procs) == 1
+
+    t1 = time.time()
+    sh.kill(procs[0])
+    t2 = time.time()
+    duration_of_kill = t2 - t1
+
+    assert not sh.find_procs_by_cmdline(DATADIR)
+    assert duration_of_kill > 5   # target process SIGTERM handler delay is 5s
+    assert duration_of_kill < 10  # sh.kill() will retry SIGKILL in 10s
+
+
+@pytest.mark.skipif(
+    os.name == 'nt',
+    reason='On Windows, os.kill() and psutil.kill() calls TerminateProcess '
+           'API which does not process signals (such as SIGTERM, SIGKILL '
+           'etc..) as ANSI/POSIX prescribed.  The TerminateProcess API '
+           'unconditionally terminates the target process.')
+def test_sigkill_sigterm_ignore():
+    """Test terminating processes resilient to SIGTERM, which would ignore the
+    initial SIGTERM it receives.  The kill() will attempt to shut the process
+    again later forcefully.
+    """
+    cmd = ['python', os.path.join(DATADIR, 'sleep20_sigterm_ignore.py')]
+    subprocess.Popen(cmd)
+    time.sleep(1)  # to allow enough time for python to start
+
+    procs = sh.find_procs_by_cmdline(DATADIR)
+    assert len(procs) == 1
+
+    t1 = time.time()
+    sh.kill(procs[0])
+    t2 = time.time()
+    duration_of_kill = t2 - t1
+
+    assert not sh.find_procs_by_cmdline(DATADIR)
+    assert duration_of_kill > 10  # sh.kill() will retry SIGKILL in 10s
+    assert duration_of_kill < 20  # target process only runs this long


### PR DESCRIPTION
For issue 1: Two new unit tests for kill() around SIGTERM handling.  On e test with a process (python script) that gracefully shuts down in 5s, and the other test with a process that completely ignores SIGTERM.